### PR TITLE
REFACTOR: Remove getType() override to allow extensibility

### DIFF
--- a/src/Elements/ElementImage.php
+++ b/src/Elements/ElementImage.php
@@ -21,12 +21,12 @@ class ElementImage extends BaseElement
     /**
      * @return string
      */
-    private static $singular_name = 'Image Element';
+    private static $singular_name = 'Image';
 
     /**
      * @return string
      */
-    private static $plural_name = 'Image Elements';
+    private static $plural_name = 'Image Blocks';
 
     /**
      * @var string
@@ -85,13 +85,5 @@ class ElementImage extends BaseElement
         $blockSchema['content'] = $this->getSummary();
 
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Image');
     }
 }


### PR DESCRIPTION
## Summary

Remove the `getType()` method override so the element inherits `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `ElementImage`
- Updated `$singular_name` from `'Image Element'` to `'Image'`
- Updated `$plural_name` from `'Image Elements'` to `'Image Blocks'`

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the override, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #13

Related: dynamic/silverstripe-essentials-tools#68