### PR TITLE
Merge SS5 branch (3) into SS6 branch (4)

### DIFF
--- a/src/Elements/ElementImage.php
+++ b/src/Elements/ElementImage.php
@@ -21,12 +21,12 @@ class ElementImage extends BaseElement
     /**
      * @return string
      */
-    private static $singular_name = 'Image Element';
+    private static $singular_name = 'Image';
 
     /**
      * @return string
      */
-    private static $plural_name = 'Image Elements';
+    private static $plural_name = 'Image Blocks';
 
     /**
      * @var string
@@ -85,13 +85,5 @@ class ElementImage extends BaseElement
         $blockSchema['content'] = $this->getSummary();
 
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Image');
     }
 }


### PR DESCRIPTION
## Summary

Merge the SS5 branch into the SS6 branch to bring forward the `getType()` refactor changes.

## Changes from SS5 branch

- Removed `getType()` method override to allow extensibility via `$singular_name`

## Related

- Original SS5 PR: #14
- Parent issue: dynamic/silverstripe-essentials-tools#68