### PR TITLE
docs: standardize README, centralize governance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-# Contributing
-
-Contributions are welcome! Create an issue, explaining a bug or proposal. Submit pull requests if you feel brave.

--- a/README.md
+++ b/README.md
@@ -11,17 +11,15 @@ A block to add a single image to your page.
 
 ## Requirements
 
+* php: ^8.3
 * dnadesign/silverstripe-elemental: ^6.0
 * jonom/focuspoint: ^6.0
+* silverstripe/linkfield: ^5.0
 * silverstripe/recipe-cms: ^6.0
 
 ## Installation
 
 `composer require dynamic/silverstripe-elemental-image`
-
-## License
-
-See [License](LICENSE.md)
 
 ## Example usage
 
@@ -35,32 +33,34 @@ Adds a block to display a single image on a page. Useful to break up long sectio
 #### CMS - Image Element Main Tab
 ![CMS - Image Element Main Tab](./readme-images/image-block-cms.jpg)
 
-
 ## Getting more elements
 
 See [Elemental modules by Dynamic](https://github.com/orgs/dynamic/repositories?q=elemental&type=all&language=&sort=)
 
 ## Configuration
 
-See [SilverStripe Elemental Configuration](https://github.com/silverstripe/silverstripe-elemental#configuration)
+See [SilverStripe Elemental Configuration](https://github.com/dnadesign/silverstripe-elemental#configuration)
 
 ## Maintainers
 
  *  [Dynamic](https://www.dynamicagency.com) (<dev@dynamicagency.com>)
 
 ## Bugtracker
-Bugs are tracked in the issues section of this repository. Before submitting an issue please read over
-existing issues to ensure yours is unique.
+
+Bugs are tracked in the issues section of this repository. Before submitting an issue please read over existing issues to ensure yours is unique.
 
 If the issue does look like a new bug:
 
  - Create a new issue
- - Describe the steps required to reproduce your issue, and the expected outcome. Unit tests, screenshots
- and screencasts can help here.
- - Describe your environment as detailed as possible: SilverStripe version, Browser, PHP version,
- Operating System, any installed SilverStripe modules.
+ - Describe the steps required to reproduce your issue, and the expected outcome. Unit tests, screenshots and screencasts can help here.
+ - Describe your environment as detailed as possible: SilverStripe version, Browser, PHP version, Operating System, any installed SilverStripe modules.
 
 Please report security issues to the module maintainers directly. Please don't file security issues in the bugtracker.
 
 ## Development and contribution
+
 If you would like to make contributions to the module please ensure you raise a pull request and discuss with the module maintainers.
+
+## License
+
+See [License](LICENSE.md)


### PR DESCRIPTION
Standardizes README to canonical template, removes per-repo governance files now centralized in dynamic/.github. Part of the Essentials suite-wide documentation standardization.

Changes:
- Add missing `php: ^8.3` and `silverstripe/linkfield: ^5.0` to Requirements (were in composer.json but absent from README)
- Fix Configuration link (old `silverstripe/silverstripe-elemental` → `dnadesign/silverstripe-elemental`)
- Add blank line after Bugtracker and Development headings for consistency
- Move License section to end per canonical template order
- Remove redundant CONTRIBUTING.md (org default now in dynamic/.github)